### PR TITLE
Remove wrong event binding

### DIFF
--- a/src/directives/ng-file-drop.ts
+++ b/src/directives/ng-file-drop.ts
@@ -4,8 +4,7 @@ import {Ng2Uploader} from '../services/ng2-uploader';
 @Directive({
   selector: '[ng-file-drop]',
   inputs: ['options: ng-file-drop'],
-  outputs: ['onUpload'],
-  host: { '(change)': 'onFiles()' }
+  outputs: ['onUpload']
 })
 export class NgFileDrop {
   uploader: Ng2Uploader;


### PR DESCRIPTION
The method `onFiles` is not available in this directive, the events are bound in method `initEvents`.
This removes the following runtime error:

<pre>
angular2.dev.js:23501 EXCEPTION: Error during evaluation of "change"
angular2.dev.js:23501 TypeError: this.directive_9_0.onFiles is not a function
    at AbstractChangeDetector.ChangeDetector_ProfileComponent_0.handleEventInternal (viewFactory_ProfileComponent:1841)
    at AbstractChangeDetector.handleEvent (angular2.dev.js:8036)
    at AppView.triggerEventHandlers (angular2.dev.js:10736)
    at eval (viewFactory_ProfileComponent:2181)
    at angular2.dev.js:13905
    at angular2.dev.js:13254
    at Zone.run (angular2-polyfills.js:1243)
    at Zone.run (angular2.dev.js:13456)
    at NgZone.run (angular2.dev.js:13418)
    at HTMLDivElement.outsideHandler (angular2.dev.js:13253)
</pre>