### PR TITLE
Reference angular2/typings/browser.d.ts using tsconfig.

### DIFF
--- a/ng2-uploader.d.ts
+++ b/ng2-uploader.d.ts
@@ -1,4 +1,3 @@
-/// <reference path="node_modules/angular2/typings/browser.d.ts" />
 import { Ng2Uploader } from './src/services/ng2-uploader';
 import { NgFileSelect } from './src/directives/ng-file-select';
 import { NgFileDrop } from './src/directives/ng-file-drop';

--- a/ng2-uploader.ts
+++ b/ng2-uploader.ts
@@ -1,4 +1,3 @@
-/// <reference path="node_modules/angular2/typings/browser.d.ts" />
 import {Ng2Uploader} from './src/services/ng2-uploader';
 import {NgFileSelect} from './src/directives/ng-file-select';
 import {NgFileDrop} from './src/directives/ng-file-drop';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,10 @@
     "sourceRoot": "/",
     "target": "es5"
   },
+  "files": [
+    "ng2-uploader.ts",
+    "node_modules/angular2/typings/browser.d.ts"
+  ],
   "exclude": [
     "node_modules"
   ]


### PR DESCRIPTION
I don't know too much about the referencing things.
However, after applying this patch, `prepublish` produces the same js files, and this solves the annoying #25.