### PR TITLE
Reflect-metadata 0.1.2  is no longer valid

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "clang-format": "^1.0.35",
     "es6-promise": "^3.0.2",
     "es6-shim": "^0.35.0",
-    "reflect-metadata": "0.1.2",
+    "reflect-metadata": "^0.1.3",
     "rxjs": "5.0.0-beta.2",
     "systemjs": "0.19.20",
     "zone.js": "^0.6.9"


### PR DESCRIPTION
It seems the npm does not provide 0.1.2 anymore, and tag 0.1.2 from the source github repo(@rbuckton) is not there either
https://github.com/rbuckton/ReflectDecorators/tree/v0.1.3.