### PR TITLE
in package.json specify  "main" as ng2-uploader.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ npm install ng2-uploader --save
 
 ````ts
 // app.module.ts
-import { UPLOAD_DIRECTIVES } from 'ng2-uploader';
+import { UPLOAD_DIRECTIVES } from 'ng2-uploader/ng2-uploader';
 ...
 @NgModule({
   ...

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Angular2 File Uploader",
   "version": "1.3.0",
   "license": "MIT",
-  "main": "ng2-uploader.ts",
+  "main": "ng2-uploader.js",
   "typings": "ng2-uploader.d.ts",
   "author": "Jan Kuri <jkuri88@gmail.com>",
   "scripts": {


### PR DESCRIPTION
I think (not 100% sure)   as per the typescript [publishing docs](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html)   The main  should be  the compiled  .js file

I've run into this issue on a SystemJS project.   steps to reproduce:

1) clone https://github.com/mgechev/angular-seed
2) cd angular-seed
3) npm install ng2-uploader --save

Follow your readme  instructions.


Other projects in typescript define "main" as a js file for example:
* https://github.com/auth0/angular2-jwt/blob/master/package.json
* https://github.com/karlhiramoto/ng2-file-upload/blob/development/package.json

