### PR TITLE
Issue #117

### DIFF
--- a/src/directives/ng-file-drop.ts
+++ b/src/directives/ng-file-drop.ts
@@ -6,7 +6,7 @@ import {
   Output,
   HostListener
 } from '@angular/core';
-import {Ng2Uploader} from '../services/ng2-uploader';
+import {Ng2Uploader, UploadRejected} from '../services/ng2-uploader';
 
 @Directive({
   selector: '[ngFileDrop]'
@@ -17,6 +17,7 @@ export class NgFileDropDirective {
   @Output() onUpload: EventEmitter<any> = new EventEmitter();
   @Output() onPreviewData: EventEmitter<any> = new EventEmitter();
   @Output() onFileOver:EventEmitter<any> = new EventEmitter();
+  @Output() onUploadRejected: EventEmitter<UploadRejected> = new EventEmitter<UploadRejected>();
 
    _options:any;
 
@@ -95,6 +96,8 @@ export class NgFileDropDirective {
       if (this.options.allowedExtensions.indexOf(ext) !== -1 ) {
         return true;
       }
+
+      this.onUploadRejected.emit({file: f, reason: UploadRejected.EXTENSION_NOT_ALLOWED});
 
       return false;
     });

--- a/src/directives/ng-file-drop.ts
+++ b/src/directives/ng-file-drop.ts
@@ -6,7 +6,7 @@ import {
   Output,
   HostListener
 } from '@angular/core';
-import {Ng2Uploader, UploadRejected} from '../services/ng2-uploader';
+import { Ng2Uploader, UploadRejected } from '../services/ng2-uploader';
 
 @Directive({
   selector: '[ngFileDrop]'

--- a/src/directives/ng-file-select.ts
+++ b/src/directives/ng-file-select.ts
@@ -6,7 +6,7 @@ import {
   Output,
   HostListener
 } from '@angular/core';
-import { Ng2Uploader } from '../services/ng2-uploader';
+import { Ng2Uploader, UploadRejected } from '../services/ng2-uploader';
 
 @Directive({
   selector: '[ngFileSelect]'
@@ -16,6 +16,7 @@ export class NgFileSelectDirective {
   @Input() events: EventEmitter<any>;
   @Output() onUpload: EventEmitter<any> = new EventEmitter();
   @Output() onPreviewData: EventEmitter<any> = new EventEmitter();
+  @Output() onUploadRejected: EventEmitter<UploadRejected> = new EventEmitter<UploadRejected>();
   
   _options:any;
 
@@ -73,6 +74,8 @@ export class NgFileSelectDirective {
       if (this.options.allowedExtensions.indexOf(ext) !== -1 ) {
         return true;
       }
+
+      this.onUploadRejected.emit({file: f, reason: UploadRejected.EXTENSION_NOT_ALLOWED});
 
       return false;
     });

--- a/src/services/ng2-uploader.ts
+++ b/src/services/ng2-uploader.ts
@@ -256,6 +256,15 @@ export class Ng2Uploader {
   }
 }
 
+export class UploadRejected{
+
+  public static get EXTENSION_NOT_ALLOWED():string { return "ExtensionNotAllowed"; }
+  public static get MAX_SIZE_EXCEEDED():string { return "MaxSizeExceeded"; }
+
+  file: any;
+  reason: string; 
+}
+
 function humanizeBytes(bytes: number): string {
   if (bytes === 0) {
     return '0 Byte';

--- a/src/services/ng2-uploader.ts
+++ b/src/services/ng2-uploader.ts
@@ -256,10 +256,9 @@ export class Ng2Uploader {
   }
 }
 
-export class UploadRejected{
-
-  public static get EXTENSION_NOT_ALLOWED():string { return "ExtensionNotAllowed"; }
-  public static get MAX_SIZE_EXCEEDED():string { return "MaxSizeExceeded"; }
+export class UploadRejected {
+  public static get EXTENSION_NOT_ALLOWED():string { return 'ExtensionNotAllowed'; }
+  public static get MAX_SIZE_EXCEEDED():string { return 'MaxSizeExceeded'; }
 
   file: any;
   reason: string; 


### PR DESCRIPTION
Hi @jkuri ,

as discussed the change to make it possible to get notified when an extension does not match the allowed Extensions. 

usage:

template:
```html
<input type="file" style="display: none;"
                           ngFileSelect
                           [options]="options"
                           (onUploadRejected)="handleUploadRejected($event)"
                           (onUpload)="handleUpload($event)" multiple>
```

controller:
`
import { UploadRejected } from 'ng2-uploader/ng2-uploader';

handleUploadRejected(data: UploadRejected): void {
        if (data.reason == UploadRejected.EXTENSION_NOT_ALLOWED) {
            this.error = `File ${data.file.name} could not be uploaded, because the extension is not allowed.`;
        }
        else{
            this.error = `File ${data.file.name} could not be uploaded => ${data.reason}`;
        }
    }
`

of course you can also just not import UploadRejected and work on any...