### PR TITLE
Update to Angular 2 Final

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@
 /npm-debug.log
 
 /node_modules
-/typings
+/lib

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,1 @@
 /node_modules
-/typings

--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ npm install ng2-uploader --save
 
 ````ts
 // app.module.ts
-import { UPLOAD_DIRECTIVES } from 'ng2-uploader/ng2-uploader';
+import { NgFileUploadModule } from 'ng2-uploader';
 ...
 @NgModule({
   ...
-  declarations: [
-    UPLOAD_DIRECTIVES
+  imports: [
+    NgFileUploadModule
   ],
   ...
 })

--- a/ng2-uploader.ts
+++ b/ng2-uploader.ts
@@ -1,11 +1,19 @@
-import { NgFileSelectDirective } from './src/directives/ng-file-select';
+import { NgModule } from '@angular/core';
 import { NgFileDropDirective } from './src/directives/ng-file-drop';
+import { NgFileSelectDirective } from './src/directives/ng-file-select';
+import { Ng2Uploader } from './src/services/ng2-uploader';
 
-export * from './src/services/ng2-uploader';
-export * from './src/directives/ng-file-select';
-export * from './src/directives/ng-file-drop';
-
-export const UPLOAD_DIRECTIVES: any[] = [
-  NgFileDropDirective,
-  NgFileSelectDirective
-];
+@NgModule({
+  declarations: [
+    NgFileDropDirective,
+    NgFileSelectDirective
+  ],
+  providers: [
+    Ng2Uploader
+  ],
+  exports: [
+    NgFileDropDirective,
+    NgFileSelectDirective
+  ]
+})
+export class NgFileUploadModule{}

--- a/package.json
+++ b/package.json
@@ -7,9 +7,8 @@
   "typings": "ng2-uploader.d.ts",
   "author": "Jan Kuri <jkuri88@gmail.com>",
   "scripts": {
-    "clean": "./scripts/clean.sh",
-    "dev": "tsc --watch",
-    "prepublish": "tsc"
+    "dev": "ngc",
+    "prepublish": "rimraf ./lib && ngc"
   },
   "repository": {
     "type": "git",
@@ -25,12 +24,14 @@
   ],
   "devDependencies": {
     "@angular/common": "^2.0.2",
-    "@angular/compiler": "^2.0.2",
+    "@angular/compiler": "^2.1.1",
+    "@angular/compiler-cli": "^2.1.1",
     "@angular/core": "^2.0.2",
     "core-js": "^2.4.1",
     "reflect-metadata": "^0.1.8",
+    "rimraf": "^2.5.4",
     "rxjs": "^5.0.0-beta.12",
-    "typescript": "^2.0.3",
+    "typescript": "^2.0.6",
     "zone.js": "^0.6.25"
   }
 }

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-find . -name "*.js" -type f -not -path "./node_modules/*" -delete
-find . -name "*.js.map" -type f -not -path "./node_modules/*" -delete
-find . -name "*.d.ts" -type f -not -path "./node_modules/*" -delete

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,13 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": true,
-    "target": "es5"
+    "target": "es5",
+    "outDir": "./lib"
+  },
+  "files": [
+    "./ng2-uploader.ts"
+  ],
+  "angularCompilerOptions": {
+    "skipTemplateCodegen": true
   }
 }


### PR DESCRIPTION
Adds the following updates:
- Introduces `NgFileUpload` module which encapsulates directives and service
- upgraded `typescript` dev dependency to `^2.0.0`
- remove `typings` from ignore files as they are no longer needed
- installed `@angular/compiler-cli` to generate the distributable `lib` folder, `ngc` creates specific `metadata.json` files which are required on Angular2 packages. This also enables support for Ahead of Time compilation builds
- updated `tsconfig.json`
- updated `README.md` to reflect the API changes
