### PR TITLE
Angular 2.2  AoT compiler fixes.  create NgModule

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ npm install ng2-uploader --save
 
 ````ts
 // app.module.ts
-import { UPLOAD_DIRECTIVES } from 'ng2-uploader/ng2-uploader';
+import { NgFileUploadModule } from 'ng2-uploader';
 ...
 @NgModule({
   ...
-  declarations: [
-    UPLOAD_DIRECTIVES
+  imports: [
+    NgFileUploadModule
   ],
   ...
 })
@@ -81,7 +81,7 @@ export class DemoApp {
 
 ````html
 <!-- app.component.html -->
-<input type="file" 
+<input type="file"
        ngFileSelect
        [options]="options"
        (onUpload)="handleUpload($event)">
@@ -182,9 +182,9 @@ const upload = {
       files.file.forEach((file) => {
         let fileData = fs.readFileSync(file.path);
         const originalName = file.originalFilename;
-        const generatedName = Md5(new Date().toString() + 
+        const generatedName = Md5(new Date().toString() +
           originalName) + path.extname(originalName);
-        const filePath = path.resolve(__dirname, 'uploads', 
+        const filePath = path.resolve(__dirname, 'uploads',
           generatedName);
 
         fs.writeFileSync(filePath, fileData);
@@ -230,14 +230,14 @@ const path = require('path');
 const app = express();
 app.use(cors());
 
-const upload = multer({ 
+const upload = multer({
   dest: 'uploads/',
   storage: multer.diskStorage({
     filename: (req, file, cb) => {
       let ext = path.extname(file.originalname);
       cb(null, `${Math.random().toString(36).substring(7)}${ext}`);
     }
-  }) 
+  })
 });
 
 app.post('/upload', upload.any(), (req, res) => {
@@ -258,7 +258,7 @@ app.listen(10050, () => {
 ### Backend example using plain PHP
 
 ````php
-<?php 
+<?php
 
 header("Access-Control-Allow-Origin: *");
 
@@ -274,7 +274,7 @@ if (isset($_FILES['file'])) {
   $ext = '.'.pathinfo($originalName, PATHINFO_EXTENSION);
   $generatedName = md5($_FILES['file']['tmp_name']).$ext;
   $filePath = $path.$generatedName;
-  
+
   if (!is_writable($path)) {
     echo json_encode(array(
       'status' => false,

--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ npm install ng2-uploader --save
 
 ````ts
 // app.module.ts
-import { NgFileUploadModule } from 'ng2-uploader';
+import { Ng2UploaderModule } from 'ng2-uploader';
 ...
 @NgModule({
   ...
   imports: [
-    NgFileUploadModule
+    Ng2UploaderModule
   ],
   ...
 })

--- a/ng2-uploader.ts
+++ b/ng2-uploader.ts
@@ -16,4 +16,5 @@ import { Ng2Uploader } from './src/services/ng2-uploader';
      NgFileSelectDirective
    ]
 })
-export class NgFileUploadModule{}
+export class Ng2UploaderModule{}
+

--- a/ng2-uploader.ts
+++ b/ng2-uploader.ts
@@ -1,11 +1,19 @@
-import { NgFileSelectDirective } from './src/directives/ng-file-select';
+import { NgModule } from '@angular/core';
 import { NgFileDropDirective } from './src/directives/ng-file-drop';
+import { NgFileSelectDirective } from './src/directives/ng-file-select';
+import { Ng2Uploader } from './src/services/ng2-uploader';
 
-export * from './src/services/ng2-uploader';
-export * from './src/directives/ng-file-select';
-export * from './src/directives/ng-file-drop';
-
-export const UPLOAD_DIRECTIVES: any[] = [
-  NgFileDropDirective,
-  NgFileSelectDirective
-];
+@NgModule({
+   declarations: [
+     NgFileDropDirective,
+     NgFileSelectDirective
+   ],
+   providers: [
+     Ng2Uploader
+   ],
+   exports: [
+     NgFileDropDirective,
+     NgFileSelectDirective
+   ]
+})
+export class NgFileUploadModule{}

--- a/src/directives/ng-file-drop.ts
+++ b/src/directives/ng-file-drop.ts
@@ -120,12 +120,12 @@ export class NgFileDropDirective {
   }
 
   @HostListener('dragover', ['$event'])
-  public onDragOver():void {
+  public onDragOver(event:any):void {
     this.onFileOver.emit(true);
   }
 
   @HostListener('dragleave', ['$event'])
-  public onDragLeave():any {
+  public onDragLeave(event:any):any {
     this.onFileOver.emit(false);
   }
 

--- a/src/directives/ng-file-select.ts
+++ b/src/directives/ng-file-select.ts
@@ -12,19 +12,19 @@ import { Ng2Uploader, UploadRejected } from '../services/ng2-uploader';
   selector: '[ngFileSelect]'
 })
 export class NgFileSelectDirective {
-  
+
   @Input() events: EventEmitter<any>;
   @Output() onUpload: EventEmitter<any> = new EventEmitter();
   @Output() onPreviewData: EventEmitter<any> = new EventEmitter();
   @Output() onUploadRejected: EventEmitter<UploadRejected> = new EventEmitter<UploadRejected>();
-  
+
   _options:any;
 
+  @Input()
   get options(): any {
     return this._options;
   }
 
-  @Input('options')
   set options(value: any) {
     this._options = value;
     this.uploader.setOptions(this.options);


### PR DESCRIPTION
I upgraded Angular 2.2 and started to use the [AoT compiler](https://angular.io/docs/ts/latest/cookbook/aot-compiler.html) and found some issues

Notes:
*  This includes PR  https://github.com/jkuri/ng2-uploader/pull/128  from @MaxiSantos
*  This is a more lightweight change in 29bea836de3e478c6b7027b86a0e1987b7bbad53 compared to PR  https://github.com/jkuri/ng2-uploader/pull/122 to make this a ngModule
   * I did not change package.json
   * I did not change the typings
   * I did not use compiler-cli or ngc
   * I called the module name Ng2UploaderModule


* Errors fixed in 7c79fa8c22c14f403ce9cc740bf33d5eef051e23
```
dist/tmp/node_modules/ng2-uploader/src/directives/ng-file-drop.ngfactory.ts(64,35): error TS2346: Supplied parameters do not match any signature of call target.
dist/tmp/node_modules/ng2-uploader/src/directives/ng-file-drop.ngfactory.ts(68,35): error TS2346: Supplied parameters do not match any signature of call target.
```

* Fixed in 29bea836de3e478c6b7027b86a0e1987b7bbad53
```
Error: Cannot determine the module for class NgFileDropDirective in node_modules/ng2-uploader/src/directives/ng-file-drop.ts!
    at analyzeAndValidateNgModules (node_modules/@angular/compiler/bundles/compiler.umd.js:12707:17)
    at OfflineCompiler.compileModules (node_modules/@angular/compiler/bundles/compiler.umd.js:12775:20)
    at CodeGenerator.codegen (/Users/chuckj/src/angular/modules/@angular/compiler-cli/src/codegen.ts:71:26)
    at codegen (tools/tasks/seed/compile.ahead.prod.ts:13:69)
    at Object.main (/storage/karl/Work/xsact/tools/@angular/tsc-wrapped/src/main.ts:44:12)
    at module.exports (tools/tasks/seed/compile.ahead.prod.ts:39:3)
    at AnonTask.run (tools/utils/seed/tasks_tools.ts:31:18)
    at Gulp.<anonymous> (tools/utils/seed/tasks_tools.ts:60:27)
    at module.exports (node_modules/orchestrator/lib/runTask.js:34:7)
    at Gulp.Orchestrator._runTask (node_modules/orchestrator/index.js:273:3)
Compilation failed
```
