### PR TITLE
Make package compatible with AoT Compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,11 @@
 **/*.js.map
 **/*.d.ts
 
+**/*.ngFactory.ts
+
+/compiled
+*.metadata.json
+
 /npm-debug.log
 
 /node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 
 **/*.ngFactory.ts
 
-/compiled
+/aot
 *.metadata.json
 
 /npm-debug.log

--- a/ng2-uploader.ts
+++ b/ng2-uploader.ts
@@ -1,20 +1,5 @@
-import { NgModule } from '@angular/core';
-import { NgFileDropDirective } from './src/directives/ng-file-drop';
-import { NgFileSelectDirective } from './src/directives/ng-file-select';
-import { Ng2Uploader } from './src/services/ng2-uploader';
+export * from './src/directives/ng-file-drop';
+export * from './src/directives/ng-file-select';
+export * from './src/services/ng2-uploader';
 
-@NgModule({
-   declarations: [
-     NgFileDropDirective,
-     NgFileSelectDirective
-   ],
-   providers: [
-     Ng2Uploader
-   ],
-   exports: [
-     NgFileDropDirective,
-     NgFileSelectDirective
-   ]
-})
-export class Ng2UploaderModule{}
-
+export { Ng2UploaderModule } from './src/module/ng2-uploader.module';

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "author": "Jan Kuri <jkuri88@gmail.com>",
   "scripts": {
     "clean": "./scripts/clean.sh",
-    "dev": "tsc --watch",
-    "prepublish": "tsc"
+    "dev": "ngc --watch",
+    "postinstall": "./node_modules/.bin/ngc -p tsconfig.json"
   },
   "repository": {
     "type": "git",
@@ -24,13 +24,20 @@
     "uploader"
   ],
   "devDependencies": {
-    "@angular/common": "^2.0.2",
-    "@angular/compiler": "^2.0.2",
-    "@angular/core": "^2.0.2",
-    "core-js": "^2.4.1",
+    "@angular/common": "^2.2.3",
+    "@angular/compiler": "^2.2.3",
+    "@angular/compiler-cli": "^2.2.3",
+    "@angular/core": "^2.2.3",
+    "@angular/platform-server": "^2.2.3",
+    "@angular/platform-browser": "^2.2.3",
+    "@angular/platform-browser-dynamic": "^2.2.3",
+    "@types/node": "6.0.51",
     "reflect-metadata": "^0.1.8",
-    "rxjs": "^5.0.0-beta.12",
-    "typescript": "^2.0.3",
+    "rxjs": "5.0.0-rc.4",
+    "typescript": "^2.0.10",
     "zone.js": "^0.6.25"
+  },
+  "dependencies": {
+    "@types/core-js": "^0.9.34"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ng2-uploader",
   "description": "Angular2 File Uploader",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "license": "MIT",
   "main": "ng2-uploader.js",
   "typings": "ng2-uploader.d.ts",

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -3,3 +3,4 @@
 find . -name "*.js" -type f -not -path "./node_modules/*" -delete
 find . -name "*.js.map" -type f -not -path "./node_modules/*" -delete
 find . -name "*.d.ts" -type f -not -path "./node_modules/*" -delete
+find . -name "*.metadata.json" -type f -not -path "./node_modules/*" -delete

--- a/src/module/ng2-uploader.module.ts
+++ b/src/module/ng2-uploader.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { NgFileDropDirective } from './../directives/ng-file-drop';
+import { NgFileSelectDirective } from './../directives/ng-file-select';
+import { Ng2Uploader } from './../services/ng2-uploader';
+
+@NgModule({
+   declarations: [
+     NgFileDropDirective,
+     NgFileSelectDirective
+   ],
+   providers: [
+     Ng2Uploader
+   ],
+   exports: [
+     NgFileDropDirective,
+     NgFileSelectDirective
+   ]
+})
+export class Ng2UploaderModule{}
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,35 @@
 {
   "compilerOptions": {
-    "declaration": true,
+    "target": "es5",
+    "module": "es2015",
+    "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "sourceMap": false,
+    "noEmitHelpers": false,
+    "noImplicitAny": true,
+    "declaration": true,
+    "skipLibCheck": true,
+    "stripInternal": true,
     "lib": ["es6", "dom"],
     "rootDir": ".",
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "sourceMap": true,
-    "target": "es5"
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "bundles",
+    "dist"
+  ],
+  "files": [
+    "ng2-uploader.ts"
+  ],
+  "angularCompilerOptions": {
+    "genDir": "aot",
+    "skipMetadataEmit" : false
   }
 }


### PR DESCRIPTION
This PR aims to make this package compatible with Angular 2 AoT compiler, without producing errors during this process.

The Module is now it's own file within the `src/module` directory.

The `ng2-uploader.ts` file is now an index of exports.