### PR TITLE
Moved get after set to fix issue when initializing in Angular2

### DIFF
--- a/src/directives/ng-file-drop.ts
+++ b/src/directives/ng-file-drop.ts
@@ -22,14 +22,14 @@ export class NgFileDropDirective {
 
    _options:any;
 
-  get options(): any {
-    return this._options;
-  }
-
   @Input('options')
   set options(value: any) {
     this._options = value;
     this.uploader.setOptions(this.options);
+  }
+
+  get options(): any {
+    return this._options;
   }
 
   files: any[] = [];

--- a/src/directives/ng-file-select.ts
+++ b/src/directives/ng-file-select.ts
@@ -21,14 +21,14 @@ export class NgFileSelectDirective {
 
   _options: any;
 
-  get options(): any {
-    return this._options;
-  }
-
   @Input('options')
   set options(value: any) {
     this._options = value;
     this.uploader.setOptions(this.options);
+  }
+
+  get options(): any {
+    return this._options;
   }
 
   files: any[] = [];


### PR DESCRIPTION
Fixes #151
The following is error seen when initializing a Angular2 app:
Can't bind to 'options' since it isn't a known property of 'input'.

Related to Angular2 issue:
https://github.com/angular/angular/issues/5477